### PR TITLE
[Actions] Auto-Update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -563,13 +563,13 @@ files = [
 
 [[package]]
 name = "exceptiongroup"
-version = "1.2.1"
+version = "1.2.2"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "exceptiongroup-1.2.1-py3-none-any.whl", hash = "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad"},
-    {file = "exceptiongroup-1.2.1.tar.gz", hash = "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"},
+    {file = "exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b"},
+    {file = "exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc"},
 ]
 
 [package.extras]
@@ -1675,13 +1675,13 @@ six = ">=1.5"
 
 [[package]]
 name = "python-kacl"
-version = "0.4.6"
+version = "0.5.1"
 description = "Python module and CLI tool for validating and modifying Changelogs in \"keep-a-changelog\" format\""
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "python-kacl-0.4.6.tar.gz", hash = "sha256:01b85a307d063f53a0dd0c556f4ca32b284e6a28ba5b0824e0b8d9108df23a09"},
-    {file = "python_kacl-0.4.6-py3-none-any.whl", hash = "sha256:630bdde1b0d23817717b877eddfeb2eacd4889f54e9a39164180f29769a9c7c8"},
+    {file = "python_kacl-0.5.1-py3-none-any.whl", hash = "sha256:2a74bea7734dc1ac053e36b23ee2410eb053dfa1f824139ccd9185e89653781e"},
+    {file = "python_kacl-0.5.1.tar.gz", hash = "sha256:a7d7dfea1134fc1c5861811be88ed8c780c11fe0feb1e37e5453e3ffdce3c3e1"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
The following packages are outdated

| Package                    | Used       | Update            |
|----------------------------|------------|-------------------|
| aiohttp                    | 3.8.6      | 3.10.0            |
| autoflake                  | 1.7.8      | 2.3.1             |
| babel                      | 2.14.0     | 2.15.0            |
| black                      | 23.3.0     | 24.4.2            |
| cfgv                       | 3.3.1      | 3.4.0             |
| coverage                   | 7.2.7      | 7.6.0             |
| exceptiongroup             | 1.2.1      | 1.2.2             |
| filelock                   | 3.12.2     | 3.15.4            |
| flake8                     | 3.9.2      | 7.1.0             |
| flake8-bugbear             | 23.3.12    | 24.4.26           |
| flake8-builtins            | 2.1.0      | 2.5.0             |
| flake8-comprehensions      | 3.13.0     | 3.15.0            |
| flake8-eradicate           | 1.4.0      | 1.5.0             |
| frozenlist                 | 1.3.3      | 1.4.1             |
| griffe                     | 0.22.2     | 0.48.0            |
| identify                   | 2.5.24     | 2.6.0             |
| isort                      | 5.11.5     | 5.13.2            |
| markdown                   | 3.4.4      | 3.6               |
| mccabe                     | 0.6.1      | 0.7.0             |
| mkdocs                     | 1.5.3      | 1.6.0             |
| mkdocs-autorefs            | 0.4.1      | 1.0.1             |
| mkdocs-material            | 9.2.7      | 9.5.30            |
| mkdocs-material-extensions | 1.2        | 1.3.1             |
| mkdocstrings               | 0.22.0     | 0.25.2            |
| mkdocstrings-python        | 0.7.1      | 1.10.7            |
| mypy                       | 1.4.1      | 1.11.1            |
| packaging                  | 24.0       | 24.1              |
| pathspec                   | 0.11.2     | 0.12.1            |
| pep8-naming                | 0.13.2     | 0.14.1            |
| platformdirs               | 4.0.0      | 4.2.2             |
| pluggy                     | 1.2.0      | 1.5.0             |
| pre-commit                 | 2.21.0     | 3.8.0             |
| pycodestyle                | 2.7.0      | 2.12.0            |
| pydantic                   | 1.10.17    | 2.8.2             |
| pyflakes                   | 2.3.1      | 3.2.0             |
| pygments                   | 2.17.2     | 2.18.0            |
| pymdown-extensions         | 10.2.1     | 10.9              |
| pytest                     | 7.4.4      | 8.3.2             |
| pytest-asyncio             | 0.19.0     | 0.23.8            |
| pytest-cov                 | 4.1.0      | 5.0.0             |
| pytest-socket              | 0.5.1      | 0.7.0             |
| python-kacl                | 0.4.6      | 0.6.1             |
| pyupgrade                  | 3.3.2      | 3.17.0            |
| regex                      | 2022.10.31 | 2024.7.24         |
| requests                   | 2.31.0     | 2.32.3            |
| tenacity                   | 8.2.3      | 9.0.0             |
| tokenize-rt                | 5.0.0      | 5.2.0             |
| tryceratops                | 0.1        | 2.3.3             |
| types-docutils             | 0.20.0.3   | 0.21.0.20240724   |
| types-pytz                 | 2023.3.1.1 | 2024.1.0.20240417 |
| types-setuptools           | 65.7.0.4   | 71.1.0.20240726   |
| types-six                  | 1.16.21.9  | 1.16.21.20240513  |
| types-tzlocal              | 4.3.0.0    | 5.1.0.1           |
| typing-extensions          | 4.7.1      | 4.12.2            |
| tzlocal                    | 4.3.1      | 5.2               |
| urllib3                    | 2.0.7      | 2.2.2             |
| validators                 | 0.20.0     | 0.33.0            |
| watchdog                   | 3.0.0      | 4.0.1             |