### PR TITLE
[Actions] Auto-Update dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -869,14 +869,17 @@ license = ["ukkonen"]
 
 [[package]]
 name = "idna"
-version = "3.8"
+version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "idna-3.8-py3-none-any.whl", hash = "sha256:050b4e5baadcd44d760cedbd2b8e639f2ff89bbc7a5730fcc662954303377aac"},
-    {file = "idna-3.8.tar.gz", hash = "sha256:d838c2c0ed6fced7693d5e8ab8e734d5f8fda53a039c0164afb0b82e771e3603"},
+    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
+    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
 ]
+
+[package.extras]
+all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -1697,13 +1700,13 @@ semver = "*"
 
 [[package]]
 name = "pytz"
-version = "2024.1"
+version = "2024.2"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
 files = [
-    {file = "pytz-2024.1-py2.py3-none-any.whl", hash = "sha256:328171f4e3623139da4983451950b28e95ac706e13f3f2630a879749e7a8b319"},
-    {file = "pytz-2024.1.tar.gz", hash = "sha256:2a29735ea9c18baf14b448846bde5a48030ed267578472d8955cd0e7443a9812"},
+    {file = "pytz-2024.2-py2.py3-none-any.whl", hash = "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"},
+    {file = "pytz-2024.2.tar.gz", hash = "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a"},
 ]
 
 [[package]]
@@ -2131,13 +2134,13 @@ files = [
 
 [[package]]
 name = "tzdata"
-version = "2024.1"
+version = "2024.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
 files = [
-    {file = "tzdata-2024.1-py2.py3-none-any.whl", hash = "sha256:9068bc196136463f5245e51efda838afa15aaeca9903f49050dfa2679db4d252"},
-    {file = "tzdata-2024.1.tar.gz", hash = "sha256:2674120f8d891909751c38abcdfd386ac0a5a1127954fbc332af6b5ceae07efd"},
+    {file = "tzdata-2024.2-py2.py3-none-any.whl", hash = "sha256:a48093786cdcde33cad18c2555e8532f34422074448fbc874186f0abd79565cd"},
+    {file = "tzdata-2024.2.tar.gz", hash = "sha256:7d85cc416e9382e69095b7bdf4afd9e3880418a2413feec7069d533d6b4e31cc"},
 ]
 
 [[package]]
@@ -2194,13 +2197,13 @@ test = ["flake8 (>=2.4.0)", "isort (>=4.2.2)", "pytest (>=2.2.3)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.26.3"
+version = "20.26.6"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589"},
-    {file = "virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a"},
+    {file = "virtualenv-20.26.6-py3-none-any.whl", hash = "sha256:7345cc5b25405607a624d8418154577459c3e0277f5466dd79c49d5e492995f2"},
+    {file = "virtualenv-20.26.6.tar.gz", hash = "sha256:280aede09a2a5c317e409a00102e7077c6432c5a38f0ef938e643805a7ad2c48"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
The following packages are outdated

| Package                    | Used       | Update            |
|----------------------------|------------|-------------------|
| aiohttp                    | 3.8.6      | 3.10.8            |
| autoflake                  | 1.7.8      | 2.3.1             |
| babel                      | 2.14.0     | 2.16.0            |
| black                      | 23.3.0     | 24.8.0            |
| cfgv                       | 3.3.1      | 3.4.0             |
| coverage                   | 7.2.7      | 7.6.1             |
| filelock                   | 3.12.2     | 3.16.1            |
| flake8                     | 3.9.2      | 7.1.1             |
| flake8-bugbear             | 23.3.12    | 24.8.19           |
| flake8-builtins            | 2.1.0      | 2.5.0             |
| flake8-comprehensions      | 3.13.0     | 3.15.0            |
| flake8-eradicate           | 1.4.0      | 1.5.0             |
| frozenlist                 | 1.3.3      | 1.4.1             |
| griffe                     | 0.22.2     | 1.3.1             |
| identify                   | 2.5.24     | 2.6.1             |
| idna                       | 3.8        | 3.10              |
| isort                      | 5.11.5     | 5.13.2            |
| markdown                   | 3.4.4      | 3.7               |
| mccabe                     | 0.6.1      | 0.7.0             |
| mkdocs                     | 1.5.3      | 1.6.1             |
| mkdocs-autorefs            | 0.4.1      | 1.2.0             |
| mkdocs-material            | 9.2.7      | 9.5.39            |
| mkdocs-material-extensions | 1.2        | 1.3.1             |
| mkdocstrings               | 0.22.0     | 0.26.1            |
| mkdocstrings-python        | 0.7.1      | 1.11.1            |
| multidict                  | 6.0.5      | 6.1.0             |
| mypy                       | 1.4.1      | 1.11.2            |
| packaging                  | 24.0       | 24.1              |
| pathspec                   | 0.11.2     | 0.12.1            |
| pep8-naming                | 0.13.2     | 0.14.1            |
| platformdirs               | 4.0.0      | 4.3.6             |
| pluggy                     | 1.2.0      | 1.5.0             |
| pre-commit                 | 2.21.0     | 3.8.0             |
| pycodestyle                | 2.7.0      | 2.12.1            |
| pydantic                   | 1.10.18    | 2.9.2             |
| pyflakes                   | 2.3.1      | 3.2.0             |
| pygments                   | 2.17.2     | 2.18.0            |
| pymdown-extensions         | 10.2.1     | 10.11.1           |
| pytest                     | 7.4.4      | 8.3.3             |
| pytest-asyncio             | 0.19.0     | 0.24.0            |
| pytest-cov                 | 4.1.0      | 5.0.0             |
| pytest-socket              | 0.5.1      | 0.7.0             |
| python-kacl                | 0.5.1      | 0.6.1             |
| pyupgrade                  | 3.3.2      | 3.17.0            |
| pyyaml                     | 6.0.1      | 6.0.2             |
| regex                      | 2022.10.31 | 2024.9.11         |
| requests                   | 2.31.0     | 2.32.3            |
| tenacity                   | 8.2.3      | 9.0.0             |
| tokenize-rt                | 5.0.0      | 6.0.0             |
| tryceratops                | 0.1        | 2.4.0             |
| types-docutils             | 0.20.0.3   | 0.21.0.20240907   |
| types-pytz                 | 2023.3.1.1 | 2024.2.0.20240913 |
| types-setuptools           | 65.7.0.4   | 75.1.0.20240917   |
| types-six                  | 1.16.21.9  | 1.16.21.20240513  |
| types-tzlocal              | 4.3.0.0    | 5.1.0.1           |
| typing-extensions          | 4.7.1      | 4.12.2            |
| tzdata                     | 2024.1     | 2024.2            |
| tzlocal                    | 4.3.1      | 5.2               |
| urllib3                    | 2.0.7      | 2.2.3             |
| validators                 | 0.20.0     | 0.34.0            |
| virtualenv                 | 20.26.3    | 20.26.6           |
| watchdog                   | 3.0.0      | 5.0.3             |
| yarl                       | 1.9.4      | 1.13.1            |